### PR TITLE
[Bug/5] urdf laser frame revise

### DIFF
--- a/src/minicar_description/urdf/unita_minicar.urdf
+++ b/src/minicar_description/urdf/unita_minicar.urdf
@@ -126,7 +126,7 @@
           <remapping>~/out:=/scan</remapping> 
         </ros>
         <output_type>sensor_msgs/LaserScan</output_type>
-        <frame_name>lidar_link</frame_name> 
+        <frame_name>laser</frame_name> 
       </plugin>
     </sensor>
   </gazebo>


### PR DESCRIPTION
## ✅ 공통
- **관련 Issue**: #2 
- **변경 요약(1~2줄)**:  
  Gazebo 라이다 플러그인의 `frame_name`이 TF 트리에 존재하지 않는 프레임을 가리키던 문제를 수정하여 RViz2에서 LaserScan이 정상 표시되도록 함.
- **변경 범위**: (패키지/노드/모듈)  
  `minicar_description` / `unita_minicar.urdf` (Gazebo LiDAR plugin `frame_name`)
- **검증 방법**: (어떻게 확인했는지)  
  `colcon build --packages-select minicar_description` 후 `source install/setup.bash` → 시뮬레이션 실행 → RViz2에서 `/scan` LaserScan 표시 확인.
- **주의/영향**: (없으면 “없음”)  
  없음

🐛 [bug] 버그 PR
- **문제 원인(한 줄)**:  
  `/scan` 메시지의 `header.frame_id`로 설정된 `frame_name`이 TF 트리에 없는 프레임(`lidar_link`)을 가리켜 RViz2에서 변환에 실패함.
- **해결 방식(한 줄)**:  
  `unita_minicar.urdf`의 라이다 플러그인 `frame_name`을 실제 존재하는 프레임(`laser`)로 수정함.
- **재현/해결 확인 방법**: (간단히)  
  수정 전 RViz2에서 `/scan`이 미표시 → 수정 후 rebuild 및 재실행 → RViz2에서 `/scan` LaserScan이 정상 표시됨 확인.
